### PR TITLE
Feature flag resume link

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  flags: {
+    DEV_SSR: true,
+  },
   siteMetadata: {
     title: `I'm Alex Birdsall, I make websites`,
     description: `This is a blog. It's mainly about web programming right now, I guess.`,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import { graphql } from "gatsby"
 
 import Layout from "../components/layout"
@@ -10,19 +10,41 @@ import newestFirst from "../utils/newest-first"
 
 import "./index.css"
 
-const qp = new URLSearchParams(document.location.search)
-
 const IntroductoryHeader = () => {
-  let SubtleSelfPromotion = Nothing
+  // this whole song and dance is an obnoxious, though temporary, hack
+  const [selfPromotional, setSelfPromotional] = useState(false)
 
-  if (qp.get("resume")) {
-    SubtleSelfPromotion = () => (
+  useEffect(() => {
+    const qp = new URLSearchParams(document.location.search)
+    let ms = 0
+    const step = 333
+    const max = 15000
+
+    // cf. song and dance above
+    const eachSecond = setInterval(() => {
+      ms += step
+      console.log("blip")
+      if (qp.get("resume")) {
+        setSelfPromotional(true)
+      }
+
+      if (ms > max) {
+        clearInterval(eachSecond)
+      }
+    }, step)
+
+    return () => clearInterval(eachSecond)
+  }, [])
+
+  const SubtleSelfPromotion = () =>
+    selfPromotional ? (
       <aside>
         (<a href="/resume">Here is my resumé</a>, if you're a software engineer
         hiring sort)
       </aside>
+    ) : (
+      <Nothing />
     )
-  }
 
   return (
     <introduction>


### PR DESCRIPTION
Merging via pull request as an attempt to check the quality of copilot PR reviews; the copilot reviewer remains unavailable in the UI, though, so that will have to be a follow-up. For posterity:

This code adapts the "feature flag" code to check the current url's query string for `resume=$ANYTHING_TRUTHY` to avoid errors in the gatsby SSG node environment (in which evaluating `new URLSearchParams(document.location.search)` throws) during static builds (i.e. publishing to prod). The check is wrapped in a `useEffect` (to defer evaluation in non-browser environments), whose scoping rules mean I must therefore toggle the resume link rendering via a new piece of state.

Why is there a feature flag in the first place? The link target, `/resume`, is a dynamic route to the `gh-pages` site for [another of my repos](https://github.com/ambirdsall/resume), so I can't properly sanity check it when serving from `localhost`.

(manual tests went fine, to no one's surprise)