### PR TITLE
Retire feature flag for resume link

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,59 +1,24 @@
-import React, { useEffect, useState } from "react"
+import React from "react"
 import { graphql } from "gatsby"
 
 import Layout from "../components/layout"
 import Seo from "../components/seo"
-import Nothing from "../components/nothing"
 import PostLink from "../components/post-link"
 import Triangle from "../components/triangle"
 import newestFirst from "../utils/newest-first"
 
 import "./index.css"
 
-const IntroductoryHeader = () => {
-  // this whole song and dance is an obnoxious, though temporary, hack
-  const [selfPromotional, setSelfPromotional] = useState(false)
-
-  useEffect(() => {
-    const qp = new URLSearchParams(document.location.search)
-    let ms = 0
-    const step = 333
-    const max = 15000
-
-    // cf. song and dance above
-    const eachSecond = setInterval(() => {
-      ms += step
-      console.log("blip")
-      if (qp.get("resume")) {
-        setSelfPromotional(true)
-      }
-
-      if (ms > max) {
-        clearInterval(eachSecond)
-      }
-    }, step)
-
-    return () => clearInterval(eachSecond)
-  }, [])
-
-  const SubtleSelfPromotion = () =>
-    selfPromotional ? (
-      <aside>
-        (<a href="/resume">Here is my resumé</a>, if you're a software engineer
-        hiring sort)
-      </aside>
-    ) : (
-      <Nothing />
-    )
-
-  return (
-    <introduction>
-      <h1>hello, I'm Alex Birdsall</h1>
-      <p>I make music, cook food, and build websites and computer programs</p>
-      <SubtleSelfPromotion />
-    </introduction>
-  )
-}
+const IntroductoryHeader = () => (
+  <introduction>
+    <h1>hello, I'm Alex Birdsall</h1>
+    <p>I make music, cook food, and build websites and computer programs</p>
+    <aside>
+      (<a href="/resume">Here is my resumé</a>, if you're a software engineer
+      hiring sort)
+    </aside>
+  </introduction>
+)
 
 // Group the posts by topic, with each topic sorted by recency of post.
 const postsByTopic = postNodes => {

--- a/todo.org
+++ b/todo.org
@@ -1,12 +1,26 @@
 #+title: Todo
 
-* DONE get basic mdx working
+* home page
+** DONE add link to resume
+** I say I make music; why not use this site to put something online?
 
-* TODO fix footnotes
-
-* TODO add back syntax highlighting in an mdx-compatible way
-
-* posting and toasting
-** own the libs [/]
-*** TODO ts-pattern
-*** TODO jsx
+* blog posts
+** TODO fix footnotes
+** TODO add back syntax highlighting in an mdx-compatible way
+** get org-mode posting in order
+*** automate exporting with =emacs -Q= shell script
+*** how to export tho?
+**** avoid boilerplate properties in post files
+***** set all export vars :: =.dir-locals.el= or explicitly bound in elisp script?
+**** option :: ox-html export
+***** minimal html, please, disable all OOTB nonsense
+***** how to define custom layout and styles?
+***** how to /share/ custom layout and styles?
+** posting and toasting
+*** TODO static jsx build of resume
+*** own the libs
+**** TODO ts-pattern
+**** TODO jsx
+*** TODO useful types of dialogue with an LLM
+* ngl, I'm really not feeling gatsby anymore
+** static jsx build like resume?


### PR DESCRIPTION
Opened as a second pull request for roughly the same reason I opened the prior one: in hopes of sanity testing the quality of the copilot code review feature (the public preview of which I allegedly gained access to before merging the prior PR, though who knows if it's enabled for free accounts).